### PR TITLE
Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "check": "run-p -l -c 'check:eslint --color' check:prettier",
-    "check:eslint": "eslint '**/*.js'",
-    "check:prettier": "prettier --check ."
+    "check": "run-p -l -c 'check:eslint --color'",
+    "check:eslint": "eslint '**/*.js'"
   },
   "engines": {
     "node": ">=10.0.0",

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
     "yarn": ">=1.13.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.31.0",
-    "@typescript-eslint/parser": "^2.31.0",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-react": "^7.19.0",
-    "eslint-plugin-react-hooks": "^4.0.0",
-    "prettier": "~2.0.5",
-    "typescript": "^3.9.3"
+    "@typescript-eslint/eslint-plugin": ">=2.31.0",
+    "@typescript-eslint/parser": ">=2.31.0",
+    "eslint": ">=6.8.0",
+    "eslint-config-prettier": ">=6.11.0",
+    "eslint-plugin-import": ">=2.20.2",
+    "eslint-plugin-prettier": ">=3.1.3",
+    "eslint-plugin-react": ">=7.19.0",
+    "eslint-plugin-react-hooks": ">=4.0.0",
+    "prettier": ">=2.0.5",
+    "typescript": ">=3.9.3"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {


### PR DESCRIPTION
- check:prettier不要だったので削除した
- 別にpeerDepsを `^` で固定しなくても基本的に壊れることはない & ユーザからしたら自由にバージョンを選べなくて不便なので、`>=` を使って制約を緩めた