### PR TITLE
eslint-config/eslint-plugin/parser を peerDeps ではなく deps にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,13 @@ ESLint config for @mizdra
 
 ## Install
 
-Install along with all compatible peerDeps:
-
 ```bash
-# for npm
-npx install-peerdeps @mizdra/eslint-config-mizdra --dev
-# for pnpm
-npx install-peerdeps @mizdra/eslint-config-mizdra --dev --pnpm
-# for yarn
-npx install-peerdeps @mizdra/eslint-config-mizdra --dev --yarn
-```
-
-If you don't need all the peerDeps, you can install them manually:
-
-```bash
-# basic
-npm i -D @mizdra/eslint-config-mizdra eslint eslint-plugin-import
-
-# for +typescript
-npm i -D @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
-
-# for +react
-npm i -D eslint-plugin-react eslint-plugin-react-hooks
-
-# for +prettier
-npm i -D eslint-config-prettier prettier
+npm i -D @mizdra/eslint-config-mizdra eslint
 ```
 
 ## Usage
 
-### Legacy config
+### With legacy config
 
 ```javascript
 module.exports = {
@@ -57,7 +34,7 @@ module.exports = {
 };
 ```
 
-### Flat config
+### With flat config
 
 ```javascript
 // @ts-check
@@ -101,4 +78,53 @@ export default [
   }),
   ...compat.extends('@mizdra/mizdra/+prettier'),
 ];
+```
+
+## Built-in 3rd-party packages
+
+When `eslint-config-mizdra` is installed the following packages are installed as its [`dependencies`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies) for usability. The installed version is always the latest.
+
+- [`@typescript-eslint/eslint-plugin`](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
+- [`@typescript-eslint/parser`](https://www.npmjs.com/package/@typescript-eslint/parser)
+- [`eslint-config-prettier`](https://www.npmjs.com/package/eslint-config-prettier)
+- [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import)
+- [`eslint-plugin-react`](https://www.npmjs.com/package/eslint-plugin-react)
+- [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks)
+
+## FAQ
+
+### How can we upgrade built-in 3rd-party packages?
+
+Uninstall `eslint-config-mizdra` and then reinstall it. It will then switch to the latest built-in 3rd-party packages.
+
+```bash
+npm un @mizdra/eslint-config-mizdra
+npm i -D @mizdra/eslint-config-mizdra
+```
+
+### How do we pin built-in 3rd-party packages to a specific version?
+
+Use the `overrides` field for [npm](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) and [pnpm](https://pnpm.io/ja/package_json#pnpmoverrides), or the `resolutions` field for [yarn](https://yarnpkg.com/configuration/manifest/#resolutions).
+
+```json
+// package.json
+{
+  "overrides": {
+    "@typescript-eslint/parser": "^4.0.0"
+  }
+}
+```
+
+In npm and pnpm, you can also match the version written in `dependencies`.
+
+```json
+// package.json
+{
+  "dependencies": {
+    "@typescript-eslint/parser": "^4.0.0"
+  },
+  "overrides": {
+    "@typescript-eslint/parser": "$@typescript-eslint/parser"
+  }
+}
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,14 @@
       "name": "@mizdra/eslint-config-mizdra",
       "version": "1.2.0",
       "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": ">=2.31.0",
+        "@typescript-eslint/parser": ">=2.31.0",
+        "eslint-config-prettier": ">=8.0.0",
+        "eslint-plugin-import": ">=2.20.2",
+        "eslint-plugin-react": ">=7.19.0",
+        "eslint-plugin-react-hooks": ">=4.0.0"
+      },
       "devDependencies": {
         "@eslint/eslintrc": "^2.0.2",
         "@eslint/js": "^8.38.0",
@@ -30,37 +38,13 @@
         "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">=2.31.0",
-        "@typescript-eslint/parser": ">=2.31.0",
         "eslint": ">=6.8.0",
-        "eslint-config-prettier": ">=8.0.0",
-        "eslint-plugin-import": ">=2.20.2",
-        "eslint-plugin-react": ">=7.19.0",
-        "eslint-plugin-react-hooks": ">=4.0.0",
         "prettier": ">=2.0.5",
         "typescript": ">=3.9.3"
       },
       "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "@typescript-eslint/parser": {
-          "optional": true
-        },
         "eslint": {
           "optional": false
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        },
-        "eslint-plugin-import": {
-          "optional": false
-        },
-        "eslint-plugin-react": {
-          "optional": true
-        },
-        "eslint-plugin-react-hooks": {
-          "optional": true
         },
         "prettier": {
           "optional": true

--- a/package.json
+++ b/package.json
@@ -28,37 +28,13 @@
     "node": ">=10.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=2.31.0",
-    "@typescript-eslint/parser": ">=2.31.0",
     "eslint": ">=6.8.0",
-    "eslint-config-prettier": ">=8.0.0",
-    "eslint-plugin-import": ">=2.20.2",
-    "eslint-plugin-react": ">=7.19.0",
-    "eslint-plugin-react-hooks": ">=4.0.0",
     "prettier": ">=2.0.5",
     "typescript": ">=3.9.3"
   },
   "peerDependenciesMeta": {
-    "@typescript-eslint/eslint-plugin": {
-      "optional": true
-    },
-    "@typescript-eslint/parser": {
-      "optional": true
-    },
     "eslint": {
       "optional": false
-    },
-    "eslint-config-prettier": {
-      "optional": true
-    },
-    "eslint-plugin-import": {
-      "optional": false
-    },
-    "eslint-plugin-react": {
-      "optional": true
-    },
-    "eslint-plugin-react-hooks": {
-      "optional": true
     },
     "prettier": {
       "optional": true
@@ -66,6 +42,14 @@
     "typescript": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": ">=2.31.0",
+    "@typescript-eslint/parser": ">=2.31.0",
+    "eslint-config-prettier": ">=8.0.0",
+    "eslint-plugin-import": ">=2.20.2",
+    "eslint-plugin-react": ">=7.19.0",
+    "eslint-plugin-react-hooks": ">=4.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^2.0.2",


### PR DESCRIPTION
## Breaking Changes

### `eslint-config-mizdra` が依存している eslint-config や eslint-plugin が `peerDependencies` から`dependencies` に変更されました

以前の `eslint-config-mizdra` は以下の 6 つの 3rd-party パッケージに依存していました。

- [`@typescript-eslint/eslint-plugin`](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
- [`@typescript-eslint/parser`](https://www.npmjs.com/package/@typescript-eslint/parser)
- [`eslint-config-prettier`](https://www.npmjs.com/package/eslint-config-prettier)
- [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import)
- [`eslint-plugin-react`](https://www.npmjs.com/package/eslint-plugin-react)
- [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks)

これらは `eslint-config-mizdra` の `peerDependencies` として管理していました。しかし `peerDependencies` だと、`eslint-config-mizdra` を利用するプロジェクトにて、上記 6 つのパッケージを `npm i` で明にインストールする必要があり、インストールの手間やパッケージの更新の手間が発生していました。

そこでこれらのパッケージを `peerDependencies` ではなく `dependencies` として管理するよう変更しました。これにより、`eslint-config-mizdra` を利用するプロジェクトにて、上記 6 つのパッケージの手動でのインストールが不要になります。すでにこれらのパッケージをインストールしているプロジェクトでは、新しいバージョンの `eslint-config-mizdra` に移行する際に、パッケージのアンインストールすることをお勧めします。

```bash
npm un @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-plugin-import eslint-plugin-react eslint-plugin-react-hooks
```

一方で、3rd-party パッケージの管理が `dependencies` になったことで、それらのパッケージのバージョンの固定方法や、アップグレード方法が以前と変わっています。詳しくは README の FAQ をご覧ください。


