### PR TITLE
不必要なファイルが npm publish されないように

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "typescript": "^5.0.3"
   },
   "files": [
-    "*.js"
+    "src"
   ]
 }


### PR DESCRIPTION
```console
$ npm publish --dry-run
npm notice 
npm notice 📦  @mizdra/eslint-config-mizdra@2.0.0-beta.1
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE           
npm notice 3.5kB  README.md         
npm notice 2.0kB  package.json      
npm notice 740B   src/+node.js      
npm notice 123B   src/+prettier.js  
npm notice 1.7kB  src/+react.js     
npm notice 7.0kB  src/+typescript.js
npm notice 10.1kB src/index.js      
npm notice === Tarball Details === 
npm notice name:          @mizdra/eslint-config-mizdra                
npm notice version:       2.0.0-beta.1                                
npm notice filename:      mizdra-eslint-config-mizdra-2.0.0-beta.1.tgz
npm notice package size:  9.2 kB                                      
npm notice unpacked size: 26.2 kB                                     
npm notice shasum:        f43a31c187fb9e7b89f69edccba8f329bd90cb7d    
npm notice integrity:     sha512-gh2be/yjOIHrD[...]jWvFufdUIPQZQ==    
npm notice total files:   8                                           
npm notice 
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @mizdra/eslint-config-mizdra@2.0.0-beta.1
```