### PR TITLE
Update config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=6.8.0",
+        "eslint": ">=8.50.0",
         "prettier": ">=2.0.5",
         "typescript": ">=3.9.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.1.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": ">=2.31.0",
-        "@typescript-eslint/parser": ">=2.31.0",
+        "@typescript-eslint/eslint-plugin": ">=8.1.0",
+        "@typescript-eslint/parser": ">=8.1.0",
         "eslint-config-prettier": ">=8.10.0",
         "eslint-plugin-import-x": ">=3.1.0",
         "eslint-plugin-n": ">=15.7.0",
@@ -25,8 +25,8 @@
         "@types/eslint": "^9.6.0",
         "@types/node": "^22.3.0",
         "@types/react": "^18.3.3",
-        "@typescript-eslint/eslint-plugin": "^5.58.0",
-        "@typescript-eslint/parser": "^5.58.0",
+        "@typescript-eslint/eslint-plugin": "^8.1.0",
+        "@typescript-eslint/parser": "^8.1.0",
         "eslint": "^8.50.0",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-react": "^7.32.2",
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -355,39 +355,32 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.58.0.tgz",
-      "integrity": "sha512-vxHvLhH0qgBd3/tW6/VccptSfc8FxPQIkmNTVLWcCOVqSBvqpnKkBTYrhcGlXfSnd78azwe+PsjYFj0X34/njA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.1.0.tgz",
+      "integrity": "sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/type-utils": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
-        "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.1.0",
+        "@typescript-eslint/type-utils": "8.1.0",
+        "@typescript-eslint/utils": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -396,25 +389,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
-      "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.1.0.tgz",
+      "integrity": "sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "8.1.0",
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/typescript-estree": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -423,16 +417,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-      "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.1.0.tgz",
+      "integrity": "sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -440,25 +434,22 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.58.0.tgz",
-      "integrity": "sha512-FF5vP/SKAFJ+LmR9PENql7fQVVgGDOS+dq3j+cKl9iW/9VuZC/8CFmzIP0DLKXfWKpRHawJiG70rVH+xZZbp8w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.1.0.tgz",
+      "integrity": "sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/typescript-estree": "8.1.0",
+        "@typescript-eslint/utils": "8.1.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -467,12 +458,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.1.0.tgz",
+      "integrity": "sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -480,21 +471,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz",
+      "integrity": "sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -506,43 +498,63 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
-      "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
+      "integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.1.0",
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/typescript-estree": "8.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.1.0.tgz",
+      "integrity": "sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "8.1.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1418,28 +1430,6 @@
         "eslint": ">=8.44.0"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-scope/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/eslint-utils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
@@ -1847,12 +1837,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1943,9 +1927,9 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "engines": {
         "node": ">= 4"
       }
@@ -2432,12 +2416,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
-    },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -3366,27 +3344,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=16.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=6.8.0",
+    "eslint": ">=8.50.0",
     "prettier": ">=2.0.5",
     "typescript": ">=3.9.3"
   },

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     }
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": ">=2.31.0",
-    "@typescript-eslint/parser": ">=2.31.0",
+    "@typescript-eslint/eslint-plugin": ">=8.1.0",
+    "@typescript-eslint/parser": ">=8.1.0",
     "eslint-config-prettier": ">=8.10.0",
     "eslint-plugin-import-x": ">=3.1.0",
     "eslint-plugin-n": ">=15.7.0",
@@ -61,8 +61,8 @@
     "@types/eslint": "^9.6.0",
     "@types/node": "^22.3.0",
     "@types/react": "^18.3.3",
-    "@typescript-eslint/eslint-plugin": "^5.58.0",
-    "@typescript-eslint/parser": "^5.58.0",
+    "@typescript-eslint/eslint-plugin": "^8.1.0",
+    "@typescript-eslint/parser": "^8.1.0",
     "eslint": "^8.50.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.32.2",

--- a/src/+typescript.js
+++ b/src/+typescript.js
@@ -9,8 +9,6 @@ module.exports = /** @type {const} */ ({
   },
   rules: {
     // ***** eslint *****
-    // tsc が 'use strict' を付与してくれるので、tsc に任せる
-    'strict': 0,
     // 存在しない item の import は tsc が検知してくれるので、tsc に任せる
     // ref: https://github.com/benmosher/eslint-plugin-import/issues/1341
     'import-x/named': 0,

--- a/src/+typescript.js
+++ b/src/+typescript.js
@@ -9,9 +9,7 @@ module.exports = /** @type {const} */ ({
     'plugin:import-x/typescript',
   ],
   parserOptions: {
-    // lint 対象のファイルに最も近い tsconfig.json を利用する。tsserver の挙動と同じなのでトラブルも少ないはず。
-    // ref: https://typescript-eslint.io/architecture/parser#project
-    project: true,
+    projectService: true,
   },
   rules: {
     // ***** eslint *****

--- a/src/+typescript.js
+++ b/src/+typescript.js
@@ -89,18 +89,8 @@ module.exports = /** @type {const} */ ({
     // 不要な constructor は定義しないように
     'no-useless-constructor': 0,
     '@typescript-eslint/no-useless-constructor': 2,
-    // tsc の `noUnusedLocals` や `noUnusedParameters` よりも `_` で無視できるパターンが多くて便利なので有効
+    // tsc の `noUnusedLocals`/`noUnusedParameters` を使うように
     'no-unused-vars': 0,
-    '@typescript-eslint/no-unused-vars': [
-      2,
-      {
-        argsIgnorePattern: '^_',
-        caughtErrors: 'all',
-        caughtErrorsIgnorePattern: '^_',
-        destructuredArrayIgnorePattern: '^_',
-        ignoreRestSiblings: true,
-      },
-    ],
     // 煩すぎるので off
     '@typescript-eslint/no-unsafe-argument': 0,
     // error だと未定義関数を呼び出した際に、実引数の部分まで赤く線が引かれて煩すぎる。

--- a/src/+typescript.js
+++ b/src/+typescript.js
@@ -9,9 +9,6 @@ module.exports = /** @type {const} */ ({
   },
   rules: {
     // ***** eslint *****
-    // 存在しない item の import は tsc が検知してくれるので、tsc に任せる
-    // ref: https://github.com/benmosher/eslint-plugin-import/issues/1341
-    'import-x/named': 0,
 
     // ***** @typescript-eslint *****
     // ** Supported Rules **
@@ -21,8 +18,6 @@ module.exports = /** @type {const} */ ({
     '@typescript-eslint/ban-ts-comment': 0,
     // コーディングスタイル統一のため、`<T> expr` 形式の型アサーションを禁止して `expr as T` の使用を推奨する
     '@typescript-eslint/consistent-type-assertions': 2,
-    // 強力すぎるため off に。プロジェクトごとに個別に ON にすることを想定している。
-    '@typescript-eslint/explicit-module-boundary-types': 0,
     // コーディングスタイル統一のため、命名規則を設ける
     'camelcase': 0,
     '@typescript-eslint/naming-convention': [
@@ -83,9 +78,6 @@ module.exports = /** @type {const} */ ({
         format: null,
       },
     ],
-    // `require` は静的解析と相性が悪いため禁止する。
-    // 代わりに ES Modules の使用を推奨する。
-    '@typescript-eslint/no-require-imports': 2,
     // 可読性及びコードリーディングスタイルの統一のため、promise を返す関数では async を付けることを強制する
     // require type information
     '@typescript-eslint/promise-function-async': 2,
@@ -94,17 +86,6 @@ module.exports = /** @type {const} */ ({
     '@typescript-eslint/require-array-sort-compare': 2,
 
     // ** Extension Rules **
-    // 型安全のため、`Array` コンストラクタを使って配列を生成する時は必ず型パラメーターを渡すよう強制する
-    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-array-constructor.md
-    '@typescript-eslint/no-array-constructor': 2,
-    // `string | string` のような重複した型を定義するのはミスの可能性が高いので禁止する
-    '@typescript-eslint/no-duplicate-type-constituents': 2,
-    // コードを書いている途中によく怒られて煩すぎるので off
-    '@typescript-eslint/no-empty-function': 0,
-    // eval 及び eval 相当の API はセキュリティとパフォーマンスのリスクがあるので使用を禁止する
-    // require type information
-    'no-implied-eval': 0,
-    '@typescript-eslint/no-implied-eval': 2,
     // 不要な constructor は定義しないように
     'no-useless-constructor': 0,
     '@typescript-eslint/no-useless-constructor': 2,
@@ -113,11 +94,11 @@ module.exports = /** @type {const} */ ({
     '@typescript-eslint/no-unused-vars': [
       2,
       {
-        ignoreRestSiblings: true,
-        caughtErrors: 'all',
         argsIgnorePattern: '^_',
-        destructuredArrayIgnorePattern: '^_',
+        caughtErrors: 'all',
         caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        ignoreRestSiblings: true,
       },
     ],
     // 煩すぎるので off
@@ -131,8 +112,5 @@ module.exports = /** @type {const} */ ({
     '@typescript-eslint/no-unsafe-member-access': 0,
     // 煩すぎるので off
     '@typescript-eslint/no-unsafe-return': 0,
-    // 一貫性のために `return await p` を `return p` に強制する
-    'no-return-await': 0,
-    '@typescript-eslint/return-await': 2,
   },
 });

--- a/src/+typescript.js
+++ b/src/+typescript.js
@@ -113,9 +113,6 @@ module.exports = /** @type {const} */ ({
     // require type information
     'no-implied-eval': 0,
     '@typescript-eslint/no-implied-eval': 2,
-    // リテラル値を throw するコードはミスのはずなので禁止
-    'no-throw-literal': 0,
-    '@typescript-eslint/no-throw-literal': 2,
     // 不要な constructor は定義しないように
     'no-useless-constructor': 0,
     '@typescript-eslint/no-useless-constructor': 2,

--- a/src/+typescript.js
+++ b/src/+typescript.js
@@ -3,11 +3,7 @@
 
 /** @satisfies {import('eslint').Linter.BaseConfig} */
 module.exports = /** @type {const} */ ({
-  extends: [
-    'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
-    'plugin:import-x/typescript',
-  ],
+  extends: ['plugin:@typescript-eslint/recommended-type-checked', 'plugin:import-x/typescript'],
   parserOptions: {
     projectService: true,
   },

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 /** @satisfies {import('eslint').Linter.BaseConfig} */
 module.exports = /** @type {const} */ ({
   extends: ['eslint:recommended', 'plugin:import-x/recommended'],
+  reportUnusedDisableDirectives: true,
   parserOptions: {
     // 現代では type="script" な環境で JS を書くことはまずないので、
     // デフォルトで type="module" なJSであるとして lint する

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,6 @@ module.exports = /** @type {const} */ ({
     'no-unmodified-loop-condition': 1,
     // 2 回ループすることがないループ文を禁止
     'no-unreachable-loop': 2,
-    // 未使用の private class を禁止
-    'no-unused-private-class-members': 2,
     // - `const { unusedProp, ...usedRestProps } = obj;` のようなコードはJSではよく書かれるので、`unusedProp` が未使用であると警告しないように
     // - `_` 始まりの変数は未使用変数を表す、という文化に沿って `_` 始まりの変数は未使用であっても警告しないように
     // - エラーを無視しないよう、catch 節のエラーオブジェクトが未使用の場合は警告する
@@ -78,8 +76,6 @@ module.exports = /** @type {const} */ ({
     'no-array-constructor': 2,
     // 可読性のため `arguments.caller` `arguments.callee` を禁止
     'no-caller': 2,
-    // 予期せぬ挙動になるため、case 句での変数宣言を禁止
-    'no-case-declarations': 2,
     // console の使用を警告
     'no-console': 1,
     // 煩すぎるので off

--- a/src/index.js
+++ b/src/index.js
@@ -164,8 +164,6 @@ module.exports = /** @type {const} */ ({
     'require-unicode-regexp': 2,
     // コメントの開始にはスペースを必須とする
     'spaced-comment': [2, 'always'],
-    // ESM 以外では `'use strict';` を必須とする
-    'strict': 2,
     // Symbol には説明を付ける
     'symbol-description': 2,
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,15 +31,17 @@ module.exports = /** @type {const} */ ({
     'no-unmodified-loop-condition': 1,
     // 2 回ループすることがないループ文を禁止
     'no-unreachable-loop': 2,
-    // - `const { unusedProp, ...usedRestProps } = obj;` のようなコードはJSではよく書かれるので、`unusedProp` が未使用であると警告しないように
-    // - `_` 始まりの変数は未使用変数を表す、という文化に沿って `_` 始まりの変数は未使用であっても警告しないように
-    // - エラーを無視しないよう、catch 節のエラーオブジェクトが未使用の場合は警告する
+    // 未使用変数を禁止する
     'no-unused-vars': [
       2,
       {
-        ignoreRestSiblings: true,
+        args: 'all',
         argsIgnorePattern: '^_',
         caughtErrors: 'all',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
       },
     ],
     // `val += await asyncFunc()` のようなコードはよきせぬ挙動を引き起こす可能性があるので禁止

--- a/src/index.js
+++ b/src/index.js
@@ -100,10 +100,10 @@ module.exports = /** @type {const} */ ({
     'no-new': 2,
     // new Function() は eval に近い挙動をするので禁止
     'no-new-func': 2,
-    // `new Object()` ではなく `{}` を強制する
-    'no-new-object': 2,
     // `new String()` ではなく `'foo'` を強制する
     'no-new-wrappers': 2,
+    // `new Object()` ではなく `{}` を強制する
+    'no-object-constructor': 2,
     // octal escape は使うことない & 書いてたらミスのはずなので禁止
     'no-octal-escape': 2,
     // 関数の引数への代入は禁止

--- a/src/index.js
+++ b/src/index.js
@@ -110,8 +110,6 @@ module.exports = /** @type {const} */ ({
     'no-param-reassign': 2,
     // `__proto__` は仕様で非推奨になっているので禁止
     'no-proto': 2,
-    // 一貫性のために `return await p` を `return p` に強制する
-    'no-return-await': 2,
     // コンマ演算子は使うことないので禁止
     'no-sequences': 2,
     // リテラル値を throw するコードはミスのはずなので禁止

--- a/test/case/+node.js
+++ b/test/case/+node.js
@@ -1,3 +1,2 @@
-/* eslint-disable strict -- plugin:n/recommended が機能している */
 // eslint-disable-next-line no-unused-vars, unicorn/prefer-node-protocol
 const fs = require('fs');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,8 @@
 
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
+    "noUnusedLocals": true /* Enable error reporting when local variables aren't read. */,
+    "noUnusedParameters": true /* Raise an error when a function parameter isn't read. */,
     "exactOptionalPropertyTypes": true /* Interpret optional property types as written, rather than adding 'undefined'. */,
     "noImplicitReturns": true /* Enable error reporting for codepaths that do not explicitly return in a function. */,
     "noFallthroughCasesInSwitch": true /* Enable error reporting for fallthrough cases in switch statements. */,


### PR DESCRIPTION
## Breaking Changes

- `@typescript-eslint/no-unused-vars` が無効化され、tsc の `noUnusedLocals`/`noUnusedParameters` に任せるように
  - 未使用変数を引き続き検出したい場合は、`eslint-config-mizdra` を利用するプロジェクトの `tsconfig.json` で `noUnusedLocals`/`noUnusedParameters` を有効化してください
- ESLint v8.50.0 以上が必須に