### PR TITLE
`sourceType` の判定をより厳密にする

### DIFF
--- a/src/flat/configs/base.mjs
+++ b/src/flat/configs/base.mjs
@@ -1,13 +1,14 @@
 import js from '@eslint/js';
 
 import legacyBase from '../../index.js';
-import { compat, jsPattern, tsPattern } from '../util.mjs';
+import { commonjsPattern, compat, jsPattern, tsPattern } from '../util.mjs';
 
 export const baseConfigs = /** @satisfies {import('eslint').Linter.Config[]} */ ([
-  js.configs.recommended,
-  ...compat.extends('plugin:import-x/recommended'),
+  { ...js.configs.recommended, files: [jsPattern, tsPattern] },
+  ...compat.extends('plugin:import-x/recommended').map((config) => ({ ...config, files: [jsPattern, tsPattern] })),
   {
     name: '@mizdra/eslint-config-mizdra/base',
+    files: [jsPattern, tsPattern],
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },
@@ -19,8 +20,19 @@ export const baseConfigs = /** @satisfies {import('eslint').Linter.Config[]} */ 
       // languageOptions.parserOptions.ecmaVersion は何故か 'latest' がデフォルトではない。
       parserOptions: {
         ecmaVersion: 'latest',
+        sourceType: 'module',
       },
     },
     rules: legacyBase.rules,
   },
-]).map((config) => ({ ...config, files: [jsPattern, tsPattern] }));
+  {
+    name: '@mizdra/eslint-config-mizdra/base/commonjs',
+    files: [commonjsPattern],
+    languageOptions: {
+      sourceType: 'commonjs',
+      parserOptions: {
+        sourceType: 'commonjs',
+      },
+    },
+  },
+]);

--- a/src/flat/util.mjs
+++ b/src/flat/util.mjs
@@ -4,4 +4,5 @@ const __dirname = new URL('.', import.meta.url).pathname;
 export const compat = new FlatCompat({ resolvePluginsRelativeTo: __dirname });
 
 export const jsPattern = '**/*.{js,jsx,mjs,cjs}';
-export const tsPattern = '**/*.{ts,tsx,cts,mts}';
+export const tsPattern = '**/*.{ts,tsx,mts,cts}';
+export const commonjsPattern = '**/*.{cjs,cts}';

--- a/test/case/+typescript.ts
+++ b/test/case/+typescript.ts
@@ -2,3 +2,5 @@
 const a = 1; // @typescript-eslint が機能している
 
 export {};
+// eslint-disable-next-line import-x/no-default-export
+export default 1; // eslint-plugin-import-x が機能している


### PR DESCRIPTION
## 背景
- `sourceType` の判定が一部誤っていた
  - `*.cjs` で `languageOptions.sourceType` が `'module'` になっていた
  - `*.{ts,mts,cts}` で `languageOptions.sourceType` が `'script'` になっていた
- そのせいで、一部 rule (`import-x/no-default-export` など) の挙動がおかしくなっていた

## どうなるか
- `*.{cjs,cts}` で `languageOptions.sourceType` が `'commonjs'` になるように
- `*.{ts,mts}` で `languageOptions.sourceType` が `'module'` になるように