### PR TITLE
ESLint v9.10.0+ を必須化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,15 +36,11 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@types/eslint": ">=8.56.11",
-        "eslint": ">=8.50.0",
+        "eslint": ">=9.10.0",
         "prettier": ">=2.0.5",
         "typescript": ">=3.9.3"
       },
       "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
         "eslint": {
           "optional": false
         },
@@ -247,7 +243,7 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
       "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -281,13 +277,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,6 @@
         "typescript": ">=3.9.3"
       },
       "peerDependenciesMeta": {
-        "eslint": {
-          "optional": false
-        },
         "prettier": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -31,15 +31,11 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "@types/eslint": ">=8.56.11",
-    "eslint": ">=8.50.0",
+    "eslint": ">=9.10.0",
     "prettier": ">=2.0.5",
     "typescript": ">=3.9.3"
   },
   "peerDependenciesMeta": {
-    "@types/eslint": {
-      "optional": true
-    },
     "eslint": {
       "optional": false
     },

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "typescript": ">=3.9.3"
   },
   "peerDependenciesMeta": {
-    "eslint": {
-      "optional": false
-    },
     "prettier": {
       "optional": true
     },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,16 +1,11 @@
 import type { Linter } from 'eslint';
 
 interface ESLintPluginMizdra {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  baseConfigs: Linter.FlatConfig[];
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  typescriptConfigs: Linter.FlatConfig[];
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  reactConfigs: Linter.FlatConfig[];
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  nodeConfigs: Linter.FlatConfig[];
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  prettierConfig: Linter.FlatConfig;
+  baseConfigs: Linter.Config[];
+  typescriptConfigs: Linter.Config[];
+  reactConfigs: Linter.Config[];
+  nodeConfigs: Linter.Config[];
+  prettierConfig: Linter.Config;
 }
 declare const mizdra: ESLintPluginMizdra;
 export default mizdra;


### PR DESCRIPTION
もし ESLint v8 を使いたかったら、古い eslint-config-mizdra を使ってください、ということにする。

## Breaking Changes

- ESLint v9.10.0+ を必須化