### PR TITLE
`eslint-plugin-react-hooks` のバージョンを `>=5.1.0-rc` にする

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-force=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "@eslint/compat": "^1.1.1",
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": ">=8.33.0",
         "eslint-config-prettier": ">=9.1.0",
@@ -77,15 +76,6 @@
       "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.1.1.tgz",
-      "integrity": "sha512-lpHyRyplhGPL5mGEh6M9O5nnKk0Gz4bFI+Zu6tKlPpDUN7XshWvH9C/px4UVm87IAANE0W81CEsNGbS1KlzXpA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint-config-prettier": ">=9.1.0",
         "eslint-plugin-n": ">=17.10.2",
         "eslint-plugin-react": ">=7.35.0",
-        "eslint-plugin-react-hooks": ">=4.6.2",
+        "eslint-plugin-react-hooks": ">=5.1.0-rc",
         "eslint-plugin-simple-import-sort": ">=12.1.1",
         "globals": ">=15.9.0",
         "typescript-eslint": ">=8.5.0"
@@ -1259,14 +1259,15 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "5.1.0-rc-fb9a90fa48-20240614",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-rc-fb9a90fa48-20240614.tgz",
+      "integrity": "sha512-xsiRwaDNF5wWNC4ZHLut+x/YcAxksUd9Rizt7LaEn3bV8VyYRpXnRJQlLOfYaVy9esk4DFP4zPPnoNVjq5Gc0w==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-prettier": ">=9.1.0",
     "eslint-plugin-n": ">=17.10.2",
     "eslint-plugin-react": ">=7.35.0",
-    "eslint-plugin-react-hooks": ">=4.6.2",
+    "eslint-plugin-react-hooks": ">=5.1.0-rc",
     "eslint-plugin-simple-import-sort": ">=12.1.1",
     "globals": ">=15.9.0",
     "typescript-eslint": ">=8.5.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     }
   },
   "dependencies": {
-    "@eslint/compat": "^1.1.1",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": ">=8.33.0",
     "eslint-config-prettier": ">=9.1.0",

--- a/src/configs/react.js
+++ b/src/configs/react.js
@@ -1,4 +1,3 @@
-import { fixupConfigRules } from '@eslint/compat';
 import reactPlugin from 'eslint-plugin-react';
 import globals from 'globals';
 
@@ -8,7 +7,7 @@ import { compat, jsPattern, tsPattern } from '../util.js';
 export const reactConfigs = [
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat['jsx-runtime'],
-  ...fixupConfigRules(compat.extends('plugin:react-hooks/recommended')),
+  ...compat.extends('plugin:react-hooks/recommended'),
   {
     name: '@mizdra/eslint-config-mizdra/react',
     languageOptions: {


### PR DESCRIPTION
まだ RC 版だけど、待ち切れないので使ってしまう。