### PR TITLE
TypeScript の未使用変数の検知は eslint でやるように

### DIFF
--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -101,9 +101,22 @@ export const typescriptConfigs = [
       // 不要な constructor は定義しないように
       'no-useless-constructor': 0,
       '@typescript-eslint/no-useless-constructor': 2,
-      // tsc の `noUnusedLocals`/`noUnusedParameters` を使うように
+      // tsc の `noUnusedLocals` や `noUnusedParameters` でも可能だが、linter でやったほうが小回りが効く。
+      // 例えば linter では特定のファイル (コード生成成果物など) の未使用変数を無視したり、eslint-disable-next-line したりできるが、
+      // tsc だとそれは難しい。そこで tsc ではなく linter で未使用変数を検出する。
       'no-unused-vars': 0,
-      '@typescript-eslint/no-unused-vars': 0,
+      '@typescript-eslint/no-unused-vars': [
+        2,
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
       // 煩すぎるので off
       '@typescript-eslint/no-unsafe-argument': 0,
       // error だと未定義関数を呼び出した際に、実引数の部分まで赤く線が引かれて煩すぎる。

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,8 +30,6 @@
 
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
-    "noUnusedLocals": true /* Enable error reporting when local variables aren't read. */,
-    "noUnusedParameters": true /* Raise an error when a function parameter isn't read. */,
     "exactOptionalPropertyTypes": true /* Interpret optional property types as written, rather than adding 'undefined'. */,
     "noImplicitReturns": true /* Enable error reporting for codepaths that do not explicitly return in a function. */,
     "noFallthroughCasesInSwitch": true /* Enable error reporting for fallthrough cases in switch statements. */,


### PR DESCRIPTION
- tsc の `noUnusedLocals` や `noUnusedParameters` でも可能だが、linter でやったほうが小回りが効く
  - 例えば linter では特定のファイル (コード生成成果物など) の未使用変数を無視したり、eslint-disable-next-line したりできるが、tsc だとそれは難しい
- そこで tsc ではなく linter で未使用変数を検出する

## Breaking Changes

- TypeScript の未使用変数の検知を tsc ではなく eslint でやるように
  - tsc の `noUnusedLocals` や `noUnusedParameters` オプションを有効にしている場合は、無効化してください